### PR TITLE
GitHub Action & Elaborate `Users`

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,41 @@
+name: Tag and update library
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to bump to with the 'v' prefix (example: v1.0.0)"
+        required: true
+        type: string
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up environment
+        run: |
+          GO_VERSION=`sed -n '3p' go.mod | awk '{print $2}'`
+          echo "GO_VERSION=${GO_VERSION}" >> $GITHUB_ENV
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Push tag to the latest commit
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ github.event.inputs.version }}",
+              sha: context.sha
+            })
+
+      - name: Ping the 'proxy.golang.org' to update the documentation
+        run: GOPROXY=proxy.golang.org go list -m github.com/lauslim12/basic@${{ github.event.inputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Changelog is used to keep track of version changes. The versioning scheme used is [SemVer](https://semver.org/). First integer is used for breaking change, second integer is used for major patches, and third integer is used for minor bug fixes.
 
+## Version 1.0.2 (24/03/2022)
+
+- Create GitHub action to automate releases in `workflow_dispatch`.
+- Elaborate `Users` attribute, which is a one-to-one mapping of usernames and passwords.
+
 ## Version 1.0.1 (24/03/2022)
 
 - Fix possible timing attack in the default `Authenticator` function.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ import "github.com/lauslim12/basic"
 
 ```go
 func main() {
-    users := map[string]string{"nehemiah":"nehemiah"}
+    // Create a one-to-one mapping of username and password.
+    users := map[string]string{"nehemiah":"nehemiahpassword"}
 
     // Use default authenticator function, set charset to UTF-8, use default invalid scheme response,
     // use default invalid credentials response, set custom realm, and set static user list.
@@ -67,7 +68,7 @@ func main() {
 - Test the endpoint!
 
 ```bash
-curl -u nehemiah:nehemiah <API_ENDPOINT_URL>
+curl -u nehemiah:nehemiahpassword <API_ENDPOINT_URL>
 ```
 
 - Done!
@@ -97,7 +98,7 @@ func main() {
 }
 ```
 
-- You can customize your `Authenticator` function (signature is `func(username, password string) bool`), `Charset` (defaults to `UTF-8` according to RFC 7617), `InvalidSchemeResponse` (signature is `http.Handler`), `InvalidCredentialsResponse` (signature is `http.Handler`), `Realm` (signature is `string`), and `Users` (signature is `map[string]string`). As long as it conforms to the interface / function signature, you can customize it with anything you want.
+- You can customize your `Authenticator` function (signature is `func(username, password string) bool`), `Charset` (defaults to `UTF-8` according to RFC 7617), `InvalidSchemeResponse` (signature is `http.Handler`), `InvalidCredentialsResponse` (signature is `http.Handler`), `Realm` (signature is `string`), and `Users` (signature is `map[string]string`). `Users` itself will contain the 1-to-1 mapping of username and password. As long as it conforms to the interface / function signature, you can customize it with anything you want.
 
 ## Examples
 

--- a/basic.go
+++ b/basic.go
@@ -18,7 +18,8 @@
 // As a note about the `BasicAuth` attributes, you may use the authenticator function in order to perform a more
 // sophisticated authentication logic, such as pulling your user based on their username from the database. Another thing to note is that
 // you can pass `nil` or `make(map[string]string)` to the `Users` attribute if you do not need static credentials. Finally, the
-// `WWW-Authenticate` header is only sent if both `Charset` and `Realm` are set.
+// `WWW-Authenticate` header is only sent if both `Charset` and `Realm` are set. `Users` attribute is a 1-to-1 mapping of username
+// and password.
 //
 // See example in `example/main.go`.
 package basic


### PR DESCRIPTION
Implements:

- GitHub Action to automate releases via `workflow_dispatch`. Still a manual trigger, but way better than writing `git tag v1.0.2` and `git push -u origin v1.0.2`.
- Elaborate documentation about `Users` attribute. It is a mapping which consists of `username` and `password`. Some people like to call it `user-id` and `password`, but both are used interchangeably.
- Update to version `v1.0.2`.